### PR TITLE
Add missing quotation mark

### DIFF
--- a/lua/RichPresence.lua
+++ b/lua/RichPresence.lua
@@ -331,7 +331,7 @@ if RequiredScript == "lib/managers/platformmanager" then
 			["#Job_fex"] = 					"Buluc's Mansion",
 			["#Level_fex"] = 				"Buluc's Mansion",
 			["#Job_chca"] = 				"Black Cat Heist",
-			[#Level_chca"] =				"Black Cat Heist",
+			["#Level_chca"] =				"Black Cat Heist",
 
 			--Custom Heists
 			["#Job_zm_kino"] = 					"Kino Der Minetoten", 


### PR DESCRIPTION
# Description

One of the new RichPresence entries is missing a quotation mark, which causes a crash when you enter prep.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
